### PR TITLE
Add first version of config library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore Vim swap files
+*.swp
+*.swo

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,63 @@
+# src/config.py
+
+import ujson
+
+
+#####################################
+# Global variables and default values
+#####################################
+
+_config = None
+_defaults = {
+                "elevation_servo_index": 0,
+                "azimuth_servo_index": 1,
+            }
+
+
+
+####################
+# Internal functions
+####################
+
+def _init():
+    global _config
+
+    try:
+        with open("config.json", "r") as f:
+            _config = ujson.load(f)
+    except:
+        _config = {}
+
+
+def _save():
+    global _config
+
+    with open("config.json", "w") as f:
+        ujon.dump(_config)
+
+
+
+####################
+# Inteface functions
+####################
+
+def get(key):
+    global _config
+    global _defaults
+
+    if _config is None or _defaults is None:
+        _init()
+
+    if key not in _config:
+        return _defaults[key]
+    else:
+        return _config[key]
+
+
+def set(key, value):
+    global _config
+
+    if _config is None or _defaults is None:
+        _init()
+
+    _save()

--- a/src/config.py
+++ b/src/config.py
@@ -1,39 +1,54 @@
 # src/config.py
 
+# import json as ujson # Uncomment this line for local testing
 import ujson
+import os
 
 
 #####################################
 # Global variables and default values
 #####################################
 
+CONFIG_FILENAME = "config.json"
 _config = None
 _defaults = {
+                # Elevation/azimuth servo defaults
                 "elevation_servo_index": 0,
                 "azimuth_servo_index": 1,
-            }
+                "elevation_max_rate": 0.1,
+                "azimuth_max_rate": 0.1,
 
+                # Telemetry settings
+                "telem_destaddr": "224.11.11.11",
+                "telem_destport": "31337",
+
+                # Pins
+                "gps_uart_tx": 33,
+                "gps_uart_rx": 27,
+                "i2c_servo_scl": 21,
+                "i2c_servo_sda": 22,
+                "i2c_bno_scl": 19,
+                "i2c_bno_sda": 23,
+                "i2c_screen_scl": 25,
+                "i2c_screen_sda": 26,
+
+                # Not necessary if antenny isn't a tank
+                "tank_left": [1,2],
+                "tank_right": [0,3],
+                "tank_motors": [0,1,2,3],
+            }
 
 
 ####################
 # Internal functions
 ####################
 
-def _init():
-    global _config
-
-    try:
-        with open("config.json", "r") as f:
-            _config = ujson.load(f)
-    except:
-        _config = {}
-
 
 def _save():
     global _config
 
-    with open("config.json", "w") as f:
-        ujon.dump(_config)
+    with open(CONFIG_FILENAME, "w") as f:
+        ujson.dump(_config, f)
 
 
 
@@ -41,12 +56,22 @@ def _save():
 # Inteface functions
 ####################
 
+def reload():
+    global _config
+
+    try:
+        with open(CONFIG_FILENAME, "r") as f:
+            _config = ujson.load(f)
+    except OSError:
+        _config = {}
+
+
 def get(key):
     global _config
     global _defaults
 
     if _config is None or _defaults is None:
-        _init()
+        reload()
 
     if key not in _config:
         return _defaults[key]
@@ -57,7 +82,61 @@ def get(key):
 def set(key, value):
     global _config
 
-    if _config is None or _defaults is None:
-        _init()
+    if _config is None:
+        reload()
+
+    _config[key] = value
 
     _save()
+
+
+def print_values():
+    global _config
+    global _defaults
+
+    if _config:
+        print("Config values:")
+        for key, val in _config.items():
+            print("%s: %s" % (key, ujson.dumps(val)))
+        print()
+    else:
+        print("No non-default configuration values set!")
+
+    print("Default values:")
+    for key, val in _defaults.items():
+        print("%s: %s" % (key, ujson.dumps(val)))
+    print()
+
+
+def clear(backup=True):
+    try:
+        if backup:
+            os.rename(CONFIG_FILENAME, "%s.bak" % CONFIG_FILENAME)
+        else:
+            os.remove(CONFIG_FILENAME)
+    except OSError:
+        pass
+
+    reload()
+
+
+def revert():
+    try:
+        os.rename("%s.bak" % CONFIG_FILENAME, CONFIG_FILENAME)
+        reload()
+    except OSError:
+        pass
+
+
+def remove_backup():
+    try:
+        os.remove("%s.bak" % CONFIG_FILENAME)
+    except OSError:
+        pass
+
+
+###################################
+# Main function -- loaded on import
+###################################
+
+reload()


### PR DESCRIPTION
This simple config interface stores values in a JSON file locally. It was written as an implementation-agnostic interface in case it eventually needs to be replaced with a non-JSON config implementation, for example the [MicroPython `btree` library](http://docs.micropython.org/en/v1.9.3/pyboard/library/btree.html).

Because the `config` interface stores configuration values in a file, the user can load and store config values inside their code, or the WebREPL. This makes it easy to integrate the code with the Wi-Fi console.

`config` interface functions include:

- `config.reload()` – load the configuration values from `config.json` (if it exists) into memory
- `config.get(key)` – get a stored configuration value from memory, or default value if one is not stored; raises a `KeyError` if the key is not user-set or set by default
- `config.set(key, value)` – store a value in the configuration file
- `config.print_values()` – print the values of all user-set and default values
- `config.clear(backup=True)` – remove all user-set values and delete `config.json`; if `backup` is true, then it backs up the config file to `config.json.bak`, overwriting any existing backup file
- `config.revert()` – overwrite a config file with a backup, if it exists
- `config.remove_backup()` – delete an existing `config.json.bak` file

Note: my editor automatically removed extra whitespace from blank lines, which is why there are lots of blank lines in the diff.