### PR TITLE
Adds support for multiple config files

### DIFF
--- a/mpfshell/README.md
+++ b/mpfshell/README.md
@@ -6,14 +6,18 @@
 
 2016-06-21, sw@kaltpost.de
 
-A simple shell based file explorer for ESP8266 and WiPy
-[Micropython](https://github.com/micropython/micropython) based devices.
+A FORK of a simple shell based file explorer for ESP8266 and WiPy
+[Micropython](https://github.com/micropython/micropython) based devices, modified for
+the Antenny project.
 
 The shell is a helper for up/downloading files to the ESP8266 (over serial line and Websockets)
 and WiPy (serial line and telnet). It basically offers commands to list and upload/download
 files on the flash FS of the device.
 
+New features:
+
 ![mpfshell](./doc/screenshot.png)
+
 
 Main features:
 

--- a/mpfshell/mp/pyboard.py
+++ b/mpfshell/mp/pyboard.py
@@ -148,10 +148,11 @@ class Pyboard:
         ret = ret.strip()
         return ret
 
-    def eval_string_mode(self, expr_string):
-        ret = self.exec_("print(eval({}))".format(expr_string))
+    def eval_string_expr(self, expr_string):
+        command = expr_string.encode('utf-8')
+        ret = self.exec_("print(eval({}))".format(command))
         ret = ret.strip()
-        return ret
+        return ret.decode()
 
     def exec_(self, command):
         ret, ret_err = self.exec_raw(command)

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ import os
 # Global variables and default values
 #####################################
 
-CONFIG_FILENAME = "config.json"
+CONFIG_FILENAME = ""
 _config = None
 _defaults = {
                 # Elevation/azimuth servo defaults
@@ -51,7 +51,6 @@ def _save():
         ujson.dump(_config, f)
 
 
-
 ####################
 # Inteface functions
 ####################
@@ -63,8 +62,20 @@ def reload():
         with open(CONFIG_FILENAME, "r") as f:
             _config = ujson.load(f)
     except OSError:
+        print("OSError on reload")
         _config = {}
 
+def new(name):
+    global CONFIG_FILENAME
+    CONFIG_FILENAME = name
+    with open(CONFIG_FILENAME, "w") as f:
+        ujson.dump(_defaults, f)
+    reload()
+
+def switch(name):
+    global CONFIG_FILENAME
+    CONFIG_FILENAME = name
+    reload()
 
 def get(key):
     global _config
@@ -78,6 +89,9 @@ def get(key):
     else:
         return _config[key]
 
+def get_default(key):
+    global _defaults
+    return _defaults[key]
 
 def set(key, value):
     global _config
@@ -134,6 +148,9 @@ def remove_backup():
     except OSError:
         pass
 
+
+def current_file():
+    return CONFIG_FILENAME
 
 ###################################
 # Main function -- loaded on import


### PR DESCRIPTION
Changes the commands:

- `setup` : now the syntax is `setup config_file_name.json`

Adds the commands:

- `switch <config>` : switch to using a new config file

Modifies the backend in `config.py` to make it possible.
Also adds the `eval_string_expr` function in `pyboard.py` (in `mpfshell.py`, accessed through `self.fe.eval_string_expr(string_of_expression)`. Useful for getting the result of arbitrary command on the board (it doesn't support this by default for some reason, from what I could find).