### PR TITLE
Basic try/except for disconnection when resetting through repl

### DIFF
--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -10,6 +10,7 @@ import tempfile
 import subprocess
 import time
 import shutil
+from websocket import WebSocketConnectionClosedException
 
 import colorama
 import serial
@@ -182,6 +183,13 @@ class NyanShell(mpfshell.MpFileShell):
                 args = "ser:/dev/" + args
 
         return self._connect(args)
+
+    def do_repl(self, args):
+        try:
+            super().do_repl(args)
+        except WebSocketConnectionClosedException as e:
+            self._error("Connection lost to repl")
+            self._disconnect()
 
     def do_edit(self, args):
         """edit <REMOTE_FILE>

--- a/nyansat/host/shell/nyan_explorer.py
+++ b/nyansat/host/shell/nyan_explorer.py
@@ -120,4 +120,3 @@ class NyanExplorer(MpFileExplorer, NyanPyboard):
 class NyanExplorerCaching(NyanExplorer, MpFileExplorerCaching):
     """Wrapper for MpFileExplorerCaching that includes the new NyanPyboard/NyanExplorer functionality."""
     pass
-


### PR DESCRIPTION
Tries to handle case where some does `Ctrl+D` through the `repl` using a websocket connection (soft-resetting the board). Previously the whole shell would crash. Now the error message still shows up but the shell doesnt crash and you can reconnect.