### PR TITLE
Continue refactor. AntKontrol, el/az, upload/save, some others are done.

### DIFF
--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -81,28 +81,7 @@ class NyanShell(mpfshell.MpFileShell):
         self._set_prompt_path()
 
         self.emptyline = lambda: None
-        self.prompts = {
-            "gps_uart_tx": ("GPS UART TX pin#: ", int),
-            "gps_uart_rx": ("GPS UART RX pin#: ", int),
-            "use_gps": ("Use GPS (true or false): ", bool),
-            "i2c_servo_scl": ("Servo SCL pin#: ", int),
-            "i2c_servo_sda": ("Servo SDA pin#: ", int),
-            "i2c_servo_address": ("Servo address (in decimal): ", int),
-            "i2c_bno_scl": ("BNO055 SCL pin#: ", int),
-            "i2c_bno_sda": ("BNO055 SDA pin#: ", int),
-            "i2c_bno_address": ("BNO055 address (in decimal): ", int),
-            "use_imu": ("Use IMU (true or false): ", bool),
-            "i2c_screen_scl": ("Screen SCL pin#: ", int),
-            "i2c_screen_sda": ("Screen SDA pin#: ", int),
-            "i2c_screen_address": ("Screen address (in decimal): ", int),
-            "use_screen": ("Use Screen (true or false): ", bool),
-            "elevation_servo_index": ("Servo default elevation index: ", float),
-            "azimuth_servo_index": ("Servo default azimuth index: ", float),
-            "elevation_max_rate": ("Servo elevation max rate: ", float),
-            "azimuth_max_rate": ("Servo azimuth max rate: ", float),
-            "use_webrepl": ("Use WebREPL: ", bool),
-            "use_telemetry": ("Use Telemetry: ", bool)
-        }
+
 
     def _intro(self):
         """Text that appears when shell is first launched."""
@@ -267,19 +246,15 @@ class NyanShell(mpfshell.MpFileShell):
             )
         ]
         parsed_args = parse_cli_args(args, 'setup', 1, arg_properties)
+        name, = parsed_args
         if self._is_open():
 
             try:
                 if self.fe.config_status():
-                    name, = parsed_args
                     current = self.fe.which_config()
-
                     self.fe.config_new(name)
 
-                    print(colorama.Fore.GREEN +
-                          "Welcome to Antenny!" +
-                          colorama.Fore.RESET)
-                    print("Please enter the following information about your hardware\n")
+
 
                     for k, info in self.prompts.items():
                         prompt_text, typ = info
@@ -327,7 +302,7 @@ class NyanShell(mpfshell.MpFileShell):
                         self.printer.print_error("No such configuration parameter")
                         return
 
-                    _, typ = self.prompts[key]
+                    _, typ = self.client.prompts[key]
                     try:
                         new_val = typ(new_val)
                     except ValueError as e:
@@ -344,7 +319,7 @@ class NyanShell(mpfshell.MpFileShell):
     def complete_set(self, *args):
         """Tab completion for 'set' command."""
         if self._is_open():
-            return [key for key in self.prompts.keys() if key.startswith(args[0])]
+            return [key for key in self.client.prompts.keys() if key.startswith(args[0])]
         else:
             return []
 

--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -247,40 +247,7 @@ class NyanShell(mpfshell.MpFileShell):
         ]
         parsed_args = parse_cli_args(args, 'setup', 1, arg_properties)
         name, = parsed_args
-        if self._is_open():
-
-            try:
-                if self.fe.config_status():
-                    current = self.fe.which_config()
-                    self.fe.config_new(name)
-
-
-
-                    for k, info in self.prompts.items():
-                        prompt_text, typ = info
-                        try:
-                            new_val = typ(input(prompt_text))
-                        except ValueError:
-                            new_val = self.fe.config_get_default(k)
-                            self.printer.print_error("Invalid type, setting to default value \"{}\".\nUse \"set\" to " \
-                                        "change the parameter".format(new_val))
-
-                        self.fe.config_set(k, new_val)
-
-                    if self.caching:
-                        self.fe.cache = {}
-
-                    print(colorama.Fore.GREEN +
-                          "\nConfiguration set for \"{}\"!\n".format(name) +
-                          colorama.Fore.RESET +
-                          "You can use \"set\" to change individual parameters\n" \
-                          "or \"edit\" to change the config file " \
-                          "directly")
-                else:
-                    self.printer.print_error("Could not access existing configuration object or create one.")
-
-            except PyboardError as e:
-                self.printer.print_error_and_exception("Command faulted while trying to set configuration", e)
+        self.client.setup(name)
 
     def do_set(self, args):
         """set <CONFIG_PARAM> <NEW_VAL>

--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -26,6 +26,21 @@ from nyansat.host.shell.terminal_printer import TerminalPrinter
 from nyansat.host.shell.antenny_client import AntennyClient
 
 
+def arg_exception_handler(func):
+    """
+    Decorator for catching improper arguments to the do_something commands.
+    """
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except ValueError as e:
+            logging.error(e)
+        except RuntimeError as e:
+            logging.error(e)
+
+    return wrapper
+
+
 class NyanShell(mpfshell.MpFileShell):
     """Extension of MPFShell that adds NyanSat-specific features"""
 
@@ -613,40 +628,7 @@ class NyanShell(mpfshell.MpFileShell):
         ]
         parsed_args = parse_cli_args(args, 'motortest', 2, arg_properties)
         motor, pos = parsed_args
-        # TODO: Working on this one right now.
-        """
-        #error_str = "The first parameter must be EL or AZ. <ANGLE> must be an integer or float"
-            try:
-                if self.fe.is_antenna_initialized():
-                    print("Running motor testing routine...")
-                    self.client.safemode_guard()
-                    try:
-                        motor, pos = parsed_args
-                        if motor == "EL":
-                            index = self.fe.config_get(self.fe.EL_SERVO_INDEX)
-                        elif motor == "AZ":
-                            index = self.fe.config_get(self.fe.AZ_SERVO_INDEX)
-                        else:
-                            self.printer.print_error(error_str)
-                            return
-                        pos = float(pos)
-                    except ValueError:
-                        self.printer.print_error(error_str)
-                        return
-                    data = self.fe.motor_test(index, pos)
-                    real_pos, x_angle, y_angle, z_angle = data
-
-                    # Need to do math here
-                    print("Real IMU angles: %d", real_pos)
-                    print("Expected position: %d", real_pos)
-                else:
-                    self.printer.print_error("Please run 'antkontrol start' to initialize the antenna.")
-            except PyboardError as e:
-                self.printer.print_error_and_exception(
-                    "The AntKontrol object is not responding. Restart it with 'antkontrol start'",
-                    e
-                )
-        """
+        self.client.motor_test(motor, pos)
 
     def do_elevation(self, args):
         """elevation <ELEVATION>

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -47,6 +47,12 @@ def exception_handler(func):
         except I2CNoAddressesError as e:
             logging.error(e)
             print("Did not find any I2C devices")
+        except ConfigStatusError as e:
+            logging.error(e)
+            print("Could not access existing configuration object or create one.")
+        except ConfigUnknownError as e:
+            logging.error(e)
+            print("Command faulted while trying to set configuration.")
 
     return wrapper
 
@@ -56,6 +62,28 @@ class AntennyClient(object):
     def __init__(self, fe: NyanExplorer, printer: TerminalPrinter):
         self.fe = fe
         self.printer = printer
+        self.prompts = {
+            "gps_uart_tx": ("GPS UART TX pin#: ", int),
+            "gps_uart_rx": ("GPS UART RX pin#: ", int),
+            "use_gps": ("Use GPS (true or false): ", bool),
+            "i2c_servo_scl": ("Servo SCL pin#: ", int),
+            "i2c_servo_sda": ("Servo SDA pin#: ", int),
+            "i2c_servo_address": ("Servo address (in decimal): ", int),
+            "i2c_bno_scl": ("BNO055 SCL pin#: ", int),
+            "i2c_bno_sda": ("BNO055 SDA pin#: ", int),
+            "i2c_bno_address": ("BNO055 address (in decimal): ", int),
+            "use_imu": ("Use IMU (true or false): ", bool),
+            "i2c_screen_scl": ("Screen SCL pin#: ", int),
+            "i2c_screen_sda": ("Screen SDA pin#: ", int),
+            "i2c_screen_address": ("Screen address (in decimal): ", int),
+            "use_screen": ("Use Screen (true or false): ", bool),
+            "elevation_servo_index": ("Servo default elevation index: ", float),
+            "azimuth_servo_index": ("Servo default azimuth index: ", float),
+            "elevation_max_rate": ("Servo elevation max rate: ", float),
+            "azimuth_max_rate": ("Servo azimuth max rate: ", float),
+            "use_webrepl": ("Use WebREPL: ", bool),
+            "use_telemetry": ("Use Telemetry: ", bool)
+        }
 
     def safemode_guard(self):
         """Warns user if AntKontrol is in SAFE MODE while using motor-class commands"""
@@ -182,3 +210,33 @@ class AntennyClient(object):
 
         print("real imu angles: %d", real_pos)
         print("expected position: %d", real_pos)
+
+    @exception_handler
+    def setup(self, name):
+        self.guard_open()
+        if self.fe.config_status():
+            current = self.fe.which_config()
+            print("Welcome to Antenny!")
+            print("Please enter the following information about your hardware\n")
+
+            for k, info in self.prompts.items():
+                prompt_text, typ = info
+                try:
+                    new_val = typ(input(prompt_text))
+                except ValueError:
+                    new_val = self.fe.config_get_default(k)
+                    print("Invalid type, setting to default value \"{}\".\nUse \"set\" to "
+                          "change the parameter".format(new_val))
+
+                self.fe.config_set(k, new_val)
+
+            # TODO: figure this out, do we need this (make caching by default?)
+            # if self.caching:
+                # self.fe.cache = {}
+
+            print("\nConfiguration set for \"{}\"!\n".format(name) +
+                  "You can use \"set\" to change individual parameters\n"
+                  "or \"edit\" to change the config file "
+                  "directly")
+        else:
+            raise ConfigStatusError

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -3,10 +3,11 @@ import logging
 
 from nyansat.host.shell.terminal_printer import TerminalPrinter
 from nyansat.host.shell.nyan_explorer import NyanExplorer
-from nyansat.host.shell.errors import NotVisibleError, DeviceNotOpenError, NoAntKontrolError, PyboardError
+from nyansat.host.shell.errors import *
 
 
-def antkontrol_exception(func):
+# TODO: Move error messages into the errors.py as a self.message attribute
+def exception_handler(func):
 
     def wrapper(*args, **kwargs):
         try:
@@ -20,6 +21,32 @@ def antkontrol_exception(func):
         except PyboardError as e:
             print("The AntKontrol object is not responding. Restart it with 'antkontrol start'")
             logging.error(e)
+        except AntKontrolInitError as e:
+            logging.error(e)
+            print("Error creating AntKontrol object. Please check your physical setup and configuration match up")
+        except SafeModeWarning as e:
+            logging.warning(e)
+            print("AntKontrol is in SAFE MODE. Attached motors will not move")
+            print("If you did not intend to be in SAFE MODE, check your configuration and run "
+                  "'antkontrol start'")
+        except NotVisibleError:
+            print("The satellite is not visible from your position")
+        except BNO055RegistersError as e:
+            logging.error(e)
+            print("Error: BNO055 not detected or error in writing calibration registers.")
+        except BNO055UploadError as e:
+            logging.error(e)
+            print("The AntKontrol object is either not responding or your current configuration does not support IMU "
+                  "calibration.")
+            print("You can try to restart AntKontrol by running 'antkontrol start'")
+            print("If you believe your configuration is incorrect, run 'configs' to check your configuration and "
+                  "'setup <CONFIG_FILE>' to create a new one\n")
+        except PinInputError as e:
+            logging.error(e)
+            print("Invalid type for pin number. Try again using only decimal numbers")
+        except I2CNoAddressesError as e:
+            logging.error(e)
+            print("Did not find any I2C devices")
 
     return wrapper
 
@@ -33,9 +60,7 @@ class AntennyClient(object):
     def safemode_guard(self):
         """Warns user if AntKontrol is in SAFE MODE while using motor-class commands"""
         if self.fe.is_safemode():
-            self.printer.print_error("AntKontrol is in SAFE MODE. Attached motors will not move")
-            print("If you did not intend to be in SAFE MODE, check your configuration and run "
-                  "'antkontrol start'")
+            raise SafeModeWarning
 
     def guard_open(self):
         if self.fe is None:
@@ -43,23 +68,108 @@ class AntennyClient(object):
         else:
             return True
 
-    def check_init(self):
+    def guard_init(self):
         if not self.fe.is_antenna_initialized():
             raise NoAntKontrolError
         else:
             return True
 
     def check_open_and_init(self):
-        # TODO: Update this based on how the two above will work
         self.guard_open()
-        self.check_init()
+        self.guard_init()
 
-    # Sample architecture for elevation.
-    @antkontrol_exception
+    @exception_handler
     def elevation(self, el):
         self.check_open_and_init()
         self.safemode_guard()
         self.fe.set_elevation_degree(el)
 
+    @exception_handler
+    def azimuth(self, az):
+        self.check_open_and_init()
+        self.safemode_guard()
+        self.fe.set_elevation_degree(az)
 
+    @exception_handler
+    def antkontrol(self, mode):
+        self.guard_open()
+        if mode == 'start':
+            if self.fe.is_antenna_initialized():
+                self.fe.delete_antkontrol()
 
+            # TODO: raise BNO055UploadError in nyan_explorer
+            ret = self.fe.create_antkontrol()
+            self.safemode_guard()
+            if self.fe.is_antenna_initialized():
+                print("AntKontrol initialized")
+            else:
+                raise AntKontrolInitError
+        elif mode == 'status':
+            self.guard_init()
+            if self.fe.is_safemode():
+                print("AntKontrol is running in SAFE MODE")
+            else:
+                print("AntKontrol appears to be initialized properly")
+
+    @exception_handler
+    def track(self):
+        self.guard_open()
+        self.guard_init()
+        # TODO: Get back to this, this one has a bunch of logic inside NyanExplorer
+        pass
+
+    @exception_handler
+    def cancel(self):
+        # TODO: Same as for track
+        pass
+
+    @exception_handler
+    def upload_calibration(self):
+        self.guard_open()
+        self.guard_init()
+
+        # TODO: raise BNO055UploadError in nyan_explorer
+        status = self.fe.imu_upload_calibration_profile()
+        if not status:
+            raise BNO055RegistersError
+
+    @exception_handler
+    def save_calibration(self):
+        self.guard_open()
+        self.guard_init()
+
+        # TODO: raise BNO055UploadError in nyan_explorer
+        status = self.fe.imu_save_calibration_profile()
+        if not status:
+            raise BNO055RegistersError
+
+    # TODO: This one is huge, needs to be broken up
+    @exception_handler
+    def calibrate(self):
+        pass
+
+    @exception_handler
+    def i2ctest(self):
+        print("Input the SDA pin and SCL for the I2C bus to check")
+
+        try:
+            sda = int(input("SDA Pin#: "))
+            scl = int(input("SCL Pin#: "))
+        except ValueError:
+            raise PinInputError
+
+        # TODO: raise appropriate error in nyan_explorer
+        addresses = self.fe.i2c_scan(sda, scl)
+        addresses_list = addresses.strip('] [').strip(', ')
+        if not addresses_list:
+            raise I2CNoAddressesError
+        else:
+            print("Found the following device addresses: {}".format(addresses_list))
+        print("If you had a running AntKontrol instance, be sure to restart it")
+
+    @exception_handler
+    def motor_test(self):
+        self.guard_open()
+        self.guard_init()
+        self.safemode_guard()
+        pass

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -12,14 +12,14 @@ def exception_handler(func):
     def wrapper(*args, **kwargs):
         try:
             func(*args, **kwargs)
+        except NotRespondingError as e:
+            logging.error(e)
+            print("The AntKontrol object is not responding. Restart it with 'antkontrol start'")
         except NoAntKontrolError as e:
             print("Please run 'antkontrol start' to initialize the antenna.")
             logging.error(e)
         except DeviceNotOpenError as e:
             print("Not connected to device. Use 'open' first.")
-            logging.error(e)
-        except PyboardError as e:
-            print("The AntKontrol object is not responding. Restart it with 'antkontrol start'")
             logging.error(e)
         except AntKontrolInitError as e:
             logging.error(e)
@@ -168,8 +168,17 @@ class AntennyClient(object):
         print("If you had a running AntKontrol instance, be sure to restart it")
 
     @exception_handler
-    def motor_test(self):
+    def motor_test(self, motor, pos):
         self.guard_open()
         self.guard_init()
         self.safemode_guard()
-        pass
+        if motor == 'EL':
+            index = self.fe.config_get(self.fe.EL_SERVO_INDEX)
+        elif motor == "AZ":
+            index = self.fe.config_get(self.fe.AZ_SERVO_INDEX)
+
+        data = self.fe.motor_test(index, pos)
+        real_pos, x_angle, y_angle, z_angle = data
+
+        print("real imu angles: %d", real_pos)
+        print("expected position: %d", real_pos)

--- a/nyansat/host/shell/errors.py
+++ b/nyansat/host/shell/errors.py
@@ -47,6 +47,18 @@ class I2CNoAddressesError(Exception):
     pass
 
 
+class ConfigStatusError(Exception):
+    pass
+
+
+class NoSuchConfigError(Exception):
+    pass
+
+
+class ConfigUnknownError(Exception):
+    pass
+
+
 if __name__ == '__main__':
     class W(Warning):
         print("Warning....")

--- a/nyansat/host/shell/errors.py
+++ b/nyansat/host/shell/errors.py
@@ -1,7 +1,17 @@
 from mp.pyboard import PyboardError
 
+# TODO: Fix all this: These should have self.message attributes
+
 
 class NoAntKontrolError(Exception):
+    pass
+
+
+class AntKontrolInitError(Exception):
+    pass
+
+
+class NotRespondingError(Exception):
     pass
 
 
@@ -13,3 +23,36 @@ class DeviceNotOpenError(Exception):
     pass
 
 
+class SafeModeWarning(Warning):
+    pass
+
+
+class BNO055RegistersError(Exception):
+    pass
+
+
+class BNO055UploadError(Exception):
+    pass
+
+
+class I2CScanError(Exception):
+    pass
+
+
+class PinInputError(Exception):
+    pass
+
+
+class I2CNoAddressesError(Exception):
+    pass
+
+
+if __name__ == '__main__':
+    class W(Warning):
+        print("Warning....")
+        pass
+
+    try:
+        raise W
+    except:
+        print("asdfasdf")

--- a/nyansat/host/shell/nyan_explorer.py
+++ b/nyansat/host/shell/nyan_explorer.py
@@ -29,7 +29,6 @@ class NyanExplorer(MpFileExplorer, NyanPyboard):
         """Test if there is an AntKontrol object on the board"""
         try:
             self.exec_("isinstance(api, antenny.AntennyAPI)")
-            #self.exec_("isinstance(a, antenny.AntKontrol)")
             return True
         except PyboardError:
             return False


### PR DESCRIPTION
(NOT WORKING YET)
Left to do:

- Refactor remaining `do_something`
- Move error messages into classes in `errors.py`
- Raise appropriate errors inside `nyan_explorer` functions
- Need to talk about this, possibly get rid of nyan_explorer and use a separate command_router class for all the `eval_string_expr` stuff, so that `self.fe` can just be a regualr MPFShell File Explorer for normal mpfshell functionality, and we can have our own attribute for everything to do with executing antenny commands