### PR TITLE
Fix config infinite loop

### DIFF
--- a/nyansat/station/config/config.py
+++ b/nyansat/station/config/config.py
@@ -111,7 +111,7 @@ class ConfigRepository:
                         try:
                             logging.error("Cyclic config files! Using default: "
                                           + default_config)
-                        except NameError:
+                        except (NameError, AttributeError):
                             pass
                         self._config_filename = default_config
                         self.reload()

--- a/nyansat/station/config/config.py
+++ b/nyansat/station/config/config.py
@@ -4,7 +4,10 @@ try:
     import ujson as json
 except ImportError:
     import json
-import logging
+try:
+    import logging
+except ImportError:
+    pass
 import os
 
 
@@ -105,8 +108,11 @@ class ConfigRepository:
                                                    self._config_filename)
                     if (last_loaded in loaded
                             and last_loaded != self._config_filename):
-                        logging.error("Cyclic config files! Using default: "
-                                      + default_config)
+                        try:
+                            logging.error("Cyclic config files! Using default: "
+                                          + default_config)
+                        except NameError:
+                            pass
                         self._config_filename = default_config
                         self.reload()
                         self._config["last_loaded"] = self._config_filename

--- a/nyansat/station/config/config.py
+++ b/nyansat/station/config/config.py
@@ -1,7 +1,5 @@
 # src/config.py
 
-# import json as ujson # Uncomment this line for local testing
-
 try:
     import ujson as json
 except ImportError:
@@ -107,8 +105,8 @@ class ConfigRepository:
                                                    self._config_filename)
                     if (last_loaded in loaded
                             and last_loaded != self._config_filename):
-                        logging.error(f"Cyclic config files! Using default: "
-                                      + f"{default_config}.")
+                        logging.error("Cyclic config files! Using default: "
+                                      + default_config)
                         self._config_filename = default_config
                         self.reload()
                         self._config["last_loaded"] = self._config_filename


### PR DESCRIPTION
The `config` framework was previously susceptible to infinite loops if config files specified loading other config files which pointed back to previous config files. Moreover, this was the default behavior for loading config files with names other than `config.json`. This problem has been fixed.

This commit additionally solves problems with Josh's setup script when testing my `config` updates. Turned out to be because it would `import config` in `boot.py` and would transfer `boot.py` and then re-run in order to connect to WiFi before installing `logging`, so there would always be an `ImportError` during the installation process. This would be detrimental to any later attempts to connect with the board. Fixed by (at Rafi's direction) surrounding (the lone) `logging` call with a `try`/`except` statement. This may cause it to silently behave unexpectedly in cases where there are loops, but logging has not been successfully imported. More generally, it means nothing that imports `logging` can run before a certain point in the installation process.