### PR TITLE
Feature/nyanshell refactor

### DIFF
--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -273,56 +273,21 @@ class NyanShell(mpfshell.MpFileShell):
         """
         self.client.i2ctest()
 
-    # TODO: refactor
     def do_bnotest(self, args):
         """bnotest
         Return some diagnostic data that may be helpful in connecting a BNO055 device.
         """
-        if not self._is_open():
-            return
+        arg_properties = []
+        _ = parse_cli_args(args, 'bnotest', 0, arg_properties)
+        self.client.bno_test()
 
-        print("Input the SDA pin and SCL of the BNO device to test")
-        try:
-            sda = int(input("SDA Pin#: "))
-            scl = int(input("SCL Pin#: "))
-        except ValueError:
-            self._error("Invalid type for pin number. Try again using only decimal numbers")
-            return
-
-        bno_test_diagnostics = self.client.bno_test(sda, scl)
-        print("---")
-        print("I2C bus usable?", bno_test_diagnostics.i2c_bus_scannable)
-        if len(bno_test_diagnostics.i2c_addresses) == 0:
-            print("I2C address detected? False")
-        else:
-            print("I2C address detected? True, addresses =", bno_test_diagnostics.i2c_addresses)
-        print("BNO connection established?", bno_test_diagnostics.bno_object_created)
-        print("BNO calibrated?", bno_test_diagnostics.bno_object_calibrated)
-
-    # TODO: refactor
     def do_pwmtest(self, args):
         """pwmtest
         Return some diagnostic data that may be helpful in connecting a PCA9685 device.
         """
-        if not self._is_open():
-            return
-
-        print("Input the SDA pin and SCL of the PWM driver to test")
-        try:
-            sda = int(input("SDA Pin#: "))
-            scl = int(input("SCL Pin#: "))
-        except ValueError:
-            self._error("Invalid type for pin number. Try again using only decimal numbers")
-            return
-
-        pwm_test_diagnostics = self.client.pwm_test(sda, scl)
-        print("---")
-        print("I2C bus usable?", pwm_test_diagnostics.i2c_bus_scannable)
-        if len(pwm_test_diagnostics.i2c_addresses) == 0:
-            print("I2C address detected? False")
-        else:
-            print("I2C address detected? True, addresses =", pwm_test_diagnostics.i2c_addresses)
-        print("PWM connection established?", pwm_test_diagnostics.pca_object_created)
+        arg_properties = []
+        _ = parse_cli_args(args, 'pwmtest', 0, arg_properties)
+        self.client.pwm_test()
 
     def do_calibrate(self, args):
         """calibrate

--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 import subprocess
 import time
-import shutil
 from websocket import WebSocketConnectionClosedException
 
 import colorama
@@ -43,14 +42,6 @@ def arg_exception_handler(func):
 
 class NyanShell(mpfshell.MpFileShell):
     """Extension of MPFShell that adds NyanSat-specific features"""
-
-    YES_DISPLAY_STRING = colorama.Fore.GREEN + "YES" + colorama.Fore.RESET
-    NO_DISPLAY_STRING = colorama.Fore.RED + "NO" + colorama.Fore.RESET
-    GYRO_CALIBRATION_MESSAGE = "To calibrate the gyroscope, let the sensor rest on a level surface for a few seconds."
-    ACCEL_CALIBRATION_MESSAGE = "To calibrate the accelerometer, slowly move the sensor into >=6 distinct " \
-                                "orientations,\nsome perpendicular to the xyz axes. "
-    MAGNET_CALIBRATION_MESSAGE = "To calibrate the magnetometer, move the sensor in figure-8 shapes through the air a " \
-                                 "few times. "
 
     def __init__(self, color=False, caching=False, reset=False):
         """Creates Cmd-based shell object.
@@ -328,6 +319,18 @@ class NyanShell(mpfshell.MpFileShell):
             print("I2C address detected? True, addresses =", pwm_test_diagnostics.i2c_addresses)
         print("PWM connection established?", pwm_test_diagnostics.pca_object_created)
 
+    def do_calibrate(self, args):
+        """calibrate
+        Detect IMU calibration status and provide instructions on how to
+        calibrate if necessary. If calibration is necessary, wait for the user
+        to calibrate the device and cease waiting once all sensors are
+        calibrated. Regardless of whether calibration is necessary or not, save
+        the calibration profile to the config at the end.
+        """
+        arg_properties = []
+        parsed_args = parse_cli_args(args, 'calibrate', 0, arg_properties)
+        self.client.calibrate()
+
     def complete_switch(self, *args):
         """Tab completion for switch command."""
         try:
@@ -353,157 +356,6 @@ class NyanShell(mpfshell.MpFileShell):
                     " to be calibrated" + ("..." if use_ellipsis else ""))
         else:
             return "all components calibrated!"
-
-    def _display_initial_calibration_status(
-        self,
-        calibration_status
-    ):
-        """
-        Display the initial calibration message, with status and calibration instructions.
-
-        calibration_status: A tuple of booleans representing previous calibration T/F
-                            status for the system, gyroscope, accelerometer, and magnetometer
-        """
-        system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = calibration_status
-        print("System calibrated?", f"{self.YES_DISPLAY_STRING}" if system_calibrated else self.NO_DISPLAY_STRING)
-        print("\n")
-        if gyro_calibrated:
-            print(" - Gyroscope is calibrated.")
-        else:
-            print(f" - {self.GYRO_CALIBRATION_MESSAGE}")
-
-        if accel_calibrated:
-            print(" - Accelerometer is calibrated.")
-        else:
-            print(f" - {self.ACCEL_CALIBRATION_MESSAGE}")
-
-        if magnet_calibrated:
-            print(" - Magnetometer is calibrated.")
-        else:
-            print(f" - {self.MAGNET_CALIBRATION_MESSAGE}")
-        print("\n")
-
-    def _display_loop_calibration_status(
-        self,
-        calibration_data,
-        old_calibration_status,
-        waiting_dot_count,
-        dot_counter
-    ):
-        """
-        Display calibration status, to be updated periodically.
-
-        calibration_data: A tuple of integers representing calibration status for the
-                          system, gyroscope, accelerometer, and magnetometer
-        old_calibration_status: A tuple of booleans representing previous calibration T/F
-                                status for the system, gyroscope, accelerometer, and magnetometer
-        waiting_dot_count: The number of ellipsis dots to cycle through
-        dot_counter: The index of the current ellipsis dot, in range [0, waiting_dot_count)
-        """
-
-        system_level, gyro_level, accel_level, magnet_level = calibration_data
-        system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = old_calibration_status
-
-        print(" \n" * 8, end='')
-        self._display_initial_calibration_status(old_calibration_status)
-        print(" ")
-        
-        gyro_calibrated = gyro_calibrated or gyro_level > 0
-        accel_calibrated = accel_calibrated or accel_level > 0
-        magnet_calibrated = magnet_calibrated or magnet_level > 0
-        system_calibrated = system_calibrated or system_level > 0
-
-        # Print the calibration status panel: this is the section that automatically refereshes.
-        waiting_dots = ('.' * dot_counter) + '/' + ('.' * (waiting_dot_count - dot_counter - 1))
-        print("┌ CALIBRATION STATUS")
-        print("│")
-        print("│ * Gyroscope calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {gyro_level}/3)" if gyro_calibrated else self.NO_DISPLAY_STRING)
-        print("│ * Accelerometer calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {accel_level}/3)" if accel_calibrated else self.NO_DISPLAY_STRING)
-        print("│ * Magnetometer calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {magnet_level}/3)" if magnet_calibrated else self.NO_DISPLAY_STRING)
-        print("│")
-        wait_message = self.printer.calibration_wait_message(gyro_calibrated, accel_calibrated, magnet_calibrated,
-                                                        use_ellipsis=False)
-        wait_message += (" " + waiting_dots if wait_message else "")
-
-        # Write the wait message with an appropriate amount of trailing whitespace in order
-        # to clear the line from previous longer writes
-        terminal_width, _ = shutil.get_terminal_size()
-        spacing_length = max(min(terminal_width - 3 - len(wait_message), 20), 0)
-        print(f"└ {wait_message}", " " * spacing_length)
-
-        return (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
-
-    # TODO: still refactor
-    def do_calibrate(self, args):
-        """calibrate
-        Detect IMU calibration status and provide instructions on how to
-        calibrate if necessary. If calibration is necessary, wait for the user
-        to calibrate the device and cease waiting once all sensors are
-        calibrated. Regardless of whether calibration is necessary or not, save
-        the calibration profile to the config at the end.
-        """
-        try:
-            if args:
-                self.printer.print_error("Usage: calibrate does not take arguments.")
-                return
-
-            if self._is_open() and self.client.is_antenna_initialized():
-                print("Detecting calibration status ...")
-                data = self.client.imu_calibration_status()
-                data = (data['system'], data['gyroscope'], data['accelerometer'], data['magnetometer'])
-                if not data:
-                    self.printer.print_error("Error connecting to BNO055.")
-                    return
-
-                system_level, gyro_level, accel_level, magnet_level = data
-                system_calibrated = system_level > 0
-                gyro_calibrated = gyro_level > 0
-                accel_calibrated = accel_level > 0
-                magnet_calibrated = magnet_level > 0
-                components_calibrated = (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
-                self._display_initial_calibration_status(components_calibrated)
-
-                waiting_dot_count = 4
-                dot_counter = 0
-                time.sleep(1)
-                while not (magnet_calibrated and accel_calibrated and gyro_calibrated):
-                    time.sleep(0.5)
-                    old_calibration_status = (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
-                    system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = self._display_loop_calibration_status(
-                        data,
-                        old_calibration_status,
-                        waiting_dot_count,
-                        dot_counter
-                    )
-
-                    # Re-fetch calibration data
-                    data = self.client.imu_calibration_status()
-                    data = (data['system'], data['gyroscope'], data['accelerometer'], data['magnetometer'])
-                    if not data:
-                        self.printer.print_error("Error connecting to BNO055.")
-                        return
-
-                    dot_counter = (dot_counter + 1) % waiting_dot_count
-
-                print(f"System calibration complete: {self.YES_DISPLAY_STRING}")
-                print("Saving calibration data ...")
-                self.do_save_calibration(None)
-                print("Calibration data is now saved to config.")
-            else:
-                self.printer.print_error("Please run 'antkontrol start' to initialize the antenna.")
-
-        except PyboardError as e:
-            self.printer.print_error_and_exception(
-                "The AntKontrol object is either not responding or your current configuration does not support IMU "
-                "calibration.",
-                e
-            )
-            print("You can try to restart AntKontrol by running 'antkontrol start'")
-            print("If you believe your configuration is incorrect, run 'configs' to check your configuration and "
-                  "'setup <CONFIG_FILE>' to create a new one\n")
 
     def do_save_calibration(self, args):
         """save_calibration

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -320,143 +320,43 @@ class AntennyClient(object):
         """Cancel tracking mode"""
         self.invoker.set_tracking(False)
 
-    # TODO: refactor this
-    def bno_test(self, sda, scl):
-        """
-        Create a BNO controller object for the given I2C sda/scl configuration. Uses the default
-        value of 40 for the BNO055 I2C address.
-        :param sda: Pin number for sda
-        :param scl: Pin number for scl
-        :return: A BnoTestDiagnostics object containing relevant T/F information about the setup
-        """
-        i2c_bus_scannable = False
-        i2c_addresses = []
-        bno_object_created = False
-        bno_object_calibrated = False
+    def bno_test(self):
+        self.guard_open()   # No need to guard for antenna initialization when doing diagnostics
 
-        # Test scanning I2C bus
+        print("Input the SDA pin and SCL of the BNO device to test")
         try:
-            addresses = self.i2c_scan(sda, scl)
-        except PyboardError:
-            return BnoTestDiagnostics(
-                i2c_bus_scannable,
-                i2c_addresses,
-                bno_object_created,
-                bno_object_calibrated
-            )
-        i2c_bus_scannable = True
-
-        # Test what's on the I2C bus and their addresses
-        try:
-            i2c_addresses = [int(n) for n in addresses.strip('] [').split(', ')]
-            if not i2c_addresses:
-                return BnoTestDiagnostics(
-                    i2c_bus_scannable,
-                    i2c_addresses,
-                    bno_object_created,
-                    bno_object_calibrated
-                )
+            sda = int(input("SDA Pin#: "))
+            scl = int(input("SCL Pin#: "))
         except ValueError:
-            return BnoTestDiagnostics(
-                i2c_bus_scannable,
-                i2c_addresses,
-                bno_object_created,
-                bno_object_calibrated
-            )
+            TerminalPrinter().print_error("Invalid type for pin number. Try again using only decimal numbers")
+            return
 
-        # Test creating BNO object
+        bno_test_diagnostics = self.invoker.bno_diagnostics(sda, scl)
+        print("---")
+        print("I2C bus usable?", bno_test_diagnostics.i2c_bus_scannable)
+        if len(bno_test_diagnostics.i2c_addresses) == 0:
+            print("I2C address detected? False")
+        else:
+            print("I2C address detected? True, addresses =", bno_test_diagnostics.i2c_addresses)
+        print("BNO connection established?", bno_test_diagnostics.bno_object_created)
+        print("BNO calibrated?", bno_test_diagnostics.bno_object_calibrated)
+
+    def pwm_test(self):
+        self.guard_open()   # No need to guard for antenna initialization when doing diagnostics
+
+        print("Input the SDA pin and SCL of the PWM driver to test")
         try:
-            self.exec_("from imu.imu_bno055 import Bno055ImuController")
-            self.exec_("bno = Bno055ImuController(i2c)")
-        except PyboardError:
-            return BnoTestDiagnostics(
-                i2c_bus_scannable,
-                i2c_addresses,
-                bno_object_created,
-                bno_object_calibrated
-            )
-        bno_object_created = True
-
-        # Test calibration status of BNO object
-        try:
-            calibration_status = json.loads(self.eval_string_expr("bno.get_calibration_status()"))
-            bno_object_calibrated = calibration_status['system'] > 0
-        except PyboardError:
-            bno_object_calibrated = False
-
-        return BnoTestDiagnostics(
-            i2c_bus_scannable,
-            i2c_addresses,
-            bno_object_created,
-            bno_object_calibrated
-        )
-
-    # TODO: refactor this
-    def pwm_test(self, sda, scl):
-        """
-        Create a PCA9685 controller object for the given I2C sda/scl configuration. Uses the default
-        value of 40 for the controller's address.
-        :param sda: Pin number for sda
-        :param scl: Pin number for scl
-        :return: A PwmTestDiagnostics object containing relevant T/F information about the setup
-        """
-        i2c_bus_scannable = False
-        i2c_addresses = []
-        pca_object_created = False
-
-        # Test scanning I2C bus
-        try:
-            addresses = self.i2c_scan(sda, scl)
-        except PyboardError:
-            return PwmTestDiagnostics(
-                i2c_bus_scannable,
-                i2c_addresses,
-                pca_object_created
-            )
-        i2c_bus_scannable = True
-
-        # Test what's on the I2C bus and their addresses
-        try:
-            i2c_addresses = [int(n) for n in addresses.strip('] [').split(', ')]
-            if not i2c_addresses:
-                return PwmTestDiagnostics(
-                    i2c_bus_scannable,
-                    i2c_addresses,
-                    pca_object_created
-                )
+            sda = int(input("SDA Pin#: "))
+            scl = int(input("SCL Pin#: "))
         except ValueError:
-            return PwmTestDiagnostics(
-                i2c_bus_scannable,
-                i2c_addresses,
-                pca_object_created
-            )
+            TerminalPrinter().print_error("Invalid type for pin number. Try again using only decimal numbers")
+            return
 
-        # Test creating BNO object
-        try:
-            self.exec_("from motor.motor_pca9685 import Pca9685Controller")
-            self.exec_("pca = Pca9685Controller(i2c)")
-            pca_object_created = True
-        except PyboardError:
-            pca_object_created = False
-
-        return PwmTestDiagnostics(
-            i2c_bus_scannable,
-            i2c_addresses,
-            pca_object_created
-        )
-
-
-@dataclass
-class BnoTestDiagnostics:
-    """Store diagnostic T/F values for BNO test. Used in the handling for 'bnotest' command."""
-    i2c_bus_scannable: bool
-    i2c_addresses: List[int]
-    bno_object_created: bool
-    bno_object_calibrated: bool
-
-@dataclass
-class PwmTestDiagnostics:
-    """Store diagnostic T/F values for PWM test. Used in the handling for 'pwmtest' command."""
-    i2c_bus_scannable: bool
-    i2c_addresses: List[int]
-    pca_object_created: bool
+        pwm_test_diagnostics = self.invoker.pwm_diagnostics(sda, scl)
+        print("---")
+        print("I2C bus usable?", pwm_test_diagnostics.i2c_bus_scannable)
+        if len(pwm_test_diagnostics.i2c_addresses) == 0:
+            print("I2C address detected? False")
+        else:
+            print("I2C address detected? True, addresses =", pwm_test_diagnostics.i2c_addresses)
+        print("PWM connection established?", pwm_test_diagnostics.pca_object_created)

--- a/nyansat/host/shell/command_invoker.py
+++ b/nyansat/host/shell/command_invoker.py
@@ -1,5 +1,7 @@
 import ast
+from dataclasses import dataclass
 import json
+from typing import List
 
 from nyansat.host.shell.nyan_pyboard import NyanPyboard
 from nyansat.host.shell.errors import *
@@ -208,3 +210,141 @@ class CommandInvoker(NyanPyboard):
             return ret
         except PyboardError as e:
             raise NotRespondingError(str(e))
+
+    def bno_diagnostics(self, sda, scl):
+        """
+        Create a BNO controller object for the given I2C sda/scl configuration. Uses the default
+        value of 40 for the BNO055 I2C address.
+        :param sda: Pin number for sda
+        :param scl: Pin number for scl
+        :return: A BnoTestDiagnostics object containing relevant T/F information about the setup
+        """
+        i2c_bus_scannable = False
+        i2c_addresses = []
+        bno_object_created = False
+        bno_object_calibrated = False
+
+        # Test scanning I2C bus
+        try:
+            addresses = self.i2c_scan(sda, scl)
+        except PyboardError:
+            return BnoTestDiagnostics(
+                i2c_bus_scannable,
+                i2c_addresses,
+                bno_object_created,
+                bno_object_calibrated
+            )
+        i2c_bus_scannable = True
+
+        # Test what's on the I2C bus and their addresses
+        try:
+            i2c_addresses = [int(n) for n in addresses.strip('] [').split(', ')]
+            if not i2c_addresses:
+                return BnoTestDiagnostics(
+                    i2c_bus_scannable,
+                    i2c_addresses,
+                    bno_object_created,
+                    bno_object_calibrated
+                )
+        except ValueError:
+            return BnoTestDiagnostics(
+                i2c_bus_scannable,
+                i2c_addresses,
+                bno_object_created,
+                bno_object_calibrated
+            )
+
+        # Test creating BNO object
+        try:
+            self.exec_("from imu.imu_bno055 import Bno055ImuController")
+            self.exec_("bno = Bno055ImuController(i2c)")
+        except PyboardError:
+            return BnoTestDiagnostics(
+                i2c_bus_scannable,
+                i2c_addresses,
+                bno_object_created,
+                bno_object_calibrated
+            )
+        bno_object_created = True
+
+        # Test calibration status of BNO object
+        try:
+            calibration_status = json.loads(self.eval_string_expr("bno.get_calibration_status()"))
+            bno_object_calibrated = calibration_status['system'] > 0
+        except PyboardError:
+            bno_object_calibrated = False
+
+        return BnoTestDiagnostics(
+            i2c_bus_scannable,
+            i2c_addresses,
+            bno_object_created,
+            bno_object_calibrated
+        )
+
+    def pwm_diagnostics(self, sda, scl):
+        """
+        Create a PCA9685 controller object for the given I2C sda/scl configuration. Uses the default
+        value of 40 for the controller's address.
+        :param sda: Pin number for sda
+        :param scl: Pin number for scl
+        :return: A PwmTestDiagnostics object containing relevant T/F information about the setup
+        """
+        i2c_bus_scannable = False
+        i2c_addresses = []
+        pca_object_created = False
+
+        # Test scanning I2C bus
+        try:
+            addresses = self.i2c_scan(sda, scl)
+        except PyboardError:
+            return PwmTestDiagnostics(
+                i2c_bus_scannable,
+                i2c_addresses,
+                pca_object_created
+            )
+        i2c_bus_scannable = True
+
+        # Test what's on the I2C bus and their addresses
+        try:
+            i2c_addresses = [int(n) for n in addresses.strip('] [').split(', ')]
+            if not i2c_addresses:
+                return PwmTestDiagnostics(
+                    i2c_bus_scannable,
+                    i2c_addresses,
+                    pca_object_created
+                )
+        except ValueError:
+            return PwmTestDiagnostics(
+                i2c_bus_scannable,
+                i2c_addresses,
+                pca_object_created
+            )
+
+        # Test creating BNO object
+        try:
+            self.exec_("from motor.motor_pca9685 import Pca9685Controller")
+            self.exec_("pca = Pca9685Controller(i2c)")
+            pca_object_created = True
+        except PyboardError:
+            pca_object_created = False
+
+        return PwmTestDiagnostics(
+            i2c_bus_scannable,
+            i2c_addresses,
+            pca_object_created
+        )
+
+@dataclass
+class BnoTestDiagnostics:
+    """Store diagnostic T/F values for BNO test. Used in the handling for 'bnotest' command."""
+    i2c_bus_scannable: bool
+    i2c_addresses: List[int]
+    bno_object_created: bool
+    bno_object_calibrated: bool
+
+@dataclass
+class PwmTestDiagnostics:
+    """Store diagnostic T/F values for PWM test. Used in the handling for 'pwmtest' command."""
+    i2c_bus_scannable: bool
+    i2c_addresses: List[int]
+    pca_object_created: bool

--- a/nyansat/host/shell/terminal_printer.py
+++ b/nyansat/host/shell/terminal_printer.py
@@ -1,9 +1,19 @@
 # Priting
 import sys
 import serial
+import shutil
 
+import colorama
 
 class TerminalPrinter(object):
+
+    YES_DISPLAY_STRING = colorama.Fore.GREEN + "YES" + colorama.Fore.RESET
+    NO_DISPLAY_STRING = colorama.Fore.RED + "NO" + colorama.Fore.RESET
+    GYRO_CALIBRATION_MESSAGE = "To calibrate the gyroscope, let the sensor rest on a level surface for a few seconds."
+    ACCEL_CALIBRATION_MESSAGE = "To calibrate the accelerometer, slowly move the sensor into >=6 distinct " \
+                                "orientations,\nsome perpendicular to the xyz axes. "
+    MAGNET_CALIBRATION_MESSAGE = "To calibrate the magnetometer, move the sensor in figure-8 shapes through the air a " \
+                                 "few times. "
 
     def print_error(self, string):
         print("\n" + string + "\n")
@@ -40,6 +50,87 @@ class TerminalPrinter(object):
                     " to be calibrated" + ("..." if use_ellipsis else ""))
         else:
             return "all components calibrated!"
+
+    def _display_initial_calibration_status(
+        self,
+        calibration_status
+    ):
+        """
+        Display the initial calibration message, with status and calibration instructions.
+
+        calibration_status: A tuple of booleans representing previous calibration T/F
+                            status for the system, gyroscope, accelerometer, and magnetometer
+        """
+        system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = calibration_status
+        print("System calibrated?", f"{self.YES_DISPLAY_STRING}" if system_calibrated else self.NO_DISPLAY_STRING)
+        print("\n")
+        if gyro_calibrated:
+            print(" - Gyroscope is calibrated.")
+        else:
+            print(f" - {self.GYRO_CALIBRATION_MESSAGE}")
+
+        if accel_calibrated:
+            print(" - Accelerometer is calibrated.")
+        else:
+            print(f" - {self.ACCEL_CALIBRATION_MESSAGE}")
+
+        if magnet_calibrated:
+            print(" - Magnetometer is calibrated.")
+        else:
+            print(f" - {self.MAGNET_CALIBRATION_MESSAGE}")
+        print("\n")
+
+    def _display_loop_calibration_status(
+        self,
+        calibration_data,
+        old_calibration_status,
+        waiting_dot_count,
+        dot_counter
+    ):
+        """
+        Display calibration status, to be updated periodically.
+
+        calibration_data: A tuple of integers representing calibration status for the
+                          system, gyroscope, accelerometer, and magnetometer
+        old_calibration_status: A tuple of booleans representing previous calibration T/F
+                                status for the system, gyroscope, accelerometer, and magnetometer
+        waiting_dot_count: The number of ellipsis dots to cycle through
+        dot_counter: The index of the current ellipsis dot, in range [0, waiting_dot_count)
+        """
+
+        system_level, gyro_level, accel_level, magnet_level = calibration_data
+        system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = old_calibration_status
+
+        print(" \n" * 8, end='')
+        self._display_initial_calibration_status(old_calibration_status)
+        print(" ")
+
+        gyro_calibrated = gyro_calibrated or gyro_level > 0
+        accel_calibrated = accel_calibrated or accel_level > 0
+        magnet_calibrated = magnet_calibrated or magnet_level > 0
+        system_calibrated = system_calibrated or system_level > 0
+
+        # Print the calibration status panel: this is the section that automatically refereshes.
+        waiting_dots = ('.' * dot_counter) + '/' + ('.' * (waiting_dot_count - dot_counter - 1))
+        print("┌ CALIBRATION STATUS")
+        print("│")
+        print("│ * Gyroscope calibrated?",
+                f"{self.YES_DISPLAY_STRING} (level {gyro_level}/3)" if gyro_calibrated else self.NO_DISPLAY_STRING)
+        print("│ * Accelerometer calibrated?",
+                f"{self.YES_DISPLAY_STRING} (level {accel_level}/3)" if accel_calibrated else self.NO_DISPLAY_STRING)
+        print("│ * Magnetometer calibrated?",
+                f"{self.YES_DISPLAY_STRING} (level {magnet_level}/3)" if magnet_calibrated else self.NO_DISPLAY_STRING)
+        print("│")
+        wait_message = self.calibration_wait_message(gyro_calibrated, accel_calibrated, magnet_calibrated, use_ellipsis=False)
+        wait_message += (" " + waiting_dots if wait_message else "")
+
+        # Write the wait message with an appropriate amount of trailing whitespace in order
+        # to clear the line from previous longer writes
+        terminal_width, _ = shutil.get_terminal_size()
+        spacing_length = max(min(terminal_width - 3 - len(wait_message), 20), 0)
+        print(f"└ {wait_message}", " " * spacing_length)
+
+        return (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
 
 
     pass


### PR DESCRIPTION
- Split calibrate, bnotest, and pwmtest across the three "MVC files"
- Moved some printing logic into `TerminalPrinter`
- Didn't want to mess too much with stuff outside the scope of these commands. But should `TerminalPrinter` methods be static? There's no state involved