### PR TITLE
pin interrupt calls a move thread

### DIFF
--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -54,7 +54,7 @@ class AntennyClient(object):
             "azimuth_max_rate": ("Servo azimuth max rate", float),
             "use_webrepl": ("Use WebREPL", bool),
             "use_telemetry": ("Use Telemetry", bool),
-            "enable_demo": ("Enable movement demo (short pin#4 to ground)", bool)
+            "enable_demo": ("Enable movement demo (short pin#15 to ground)", bool)
         }
 
     def initialize(self, fe: MpFileExplorer):

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -53,7 +53,8 @@ class AntennyClient(object):
             "elevation_max_rate": ("Servo elevation max rate", float),
             "azimuth_max_rate": ("Servo azimuth max rate", float),
             "use_webrepl": ("Use WebREPL", bool),
-            "use_telemetry": ("Use Telemetry", bool)
+            "use_telemetry": ("Use Telemetry", bool),
+            "enable_demo": ("Enable movement demo (short pin#4 to ground)", bool)
         }
 
     def initialize(self, fe: MpFileExplorer):

--- a/nyansat/station/antenny.py
+++ b/nyansat/station/antenny.py
@@ -1,5 +1,6 @@
 import logging
 import machine
+import _thread
 
 from config.config import ConfigRepository
 from gps.gps_basic import BasicGPSController
@@ -97,23 +98,40 @@ class AntennaController:
         return self.elevation.get_motor_position()
 
     def pin_motion_test(self, p):
+        LOG.info("entering callback")
+        # import time
+        # time.sleep(0.2)
+        p.irq(trigger=0, handler=self.pin_motion_test)
+        interrupt_pin = machine.Pin(4, machine.Pin.OUT, machine.Pin.PULL_DOWN)
+        # time.sleep(0.2)
         LOG.info("Pin 4 has been pulled down")
         LOG.info("Entering Motor Demo State")
         LOG.info("To exit this state, reboot the device")
-        p.irq(trigger=0, handler=self.pin_motion_test)
-        interrupt_pin = machine.Pin(4, machine.Pin.IN, machine.Pin.PULL_DOWN)
-        self.start_motion(45, 45)
+        # state = machine.disable_irq()
+        # p.irq(trigger=0, handler=self.pin_motion_test)
+        # interrupt_pin = machine.Pin(4, machine.Pin.OUT, machine.Pin.PULL_DOWN)
+        _thread.start_new_thread(self.move_thread, ())
+        # machine.enable_irq(state)
+
+    def move_thread(self):
         import time
-        time.sleep(15)
+        LOG.info("Entering move thread, starting while loop")
+        self.elevation.set_motor_position(45)
+        LOG.info("got past first elevation set")
+        time.sleep(5)
+        self.azimuth.set_motor_position(45)
+        LOG.info("got past second eleavtion set")
+        time.sleep(10)
         while True:
-            self.set_elevation(20)
+            self.elevation.set_motor_position(20)
             time.sleep(1)
-            self.set_azimuth(20)
+            self.azimuth.set_motor_position(20)
             time.sleep(15)
-            self.set_elevation(70)
+            self.elevation.set_motor_position(70)
             time.sleep(1)
-            self.set_azimuth(70)
+            self.azimuth.set_motor_position(70)
             time.sleep(15)
+
 
 
 class AntennyAPI:

--- a/nyansat/station/antenny.py
+++ b/nyansat/station/antenny.py
@@ -98,29 +98,19 @@ class AntennaController:
         return self.elevation.get_motor_position()
 
     def pin_motion_test(self, p):
-        LOG.info("entering callback")
-        # import time
-        # time.sleep(0.2)
         p.irq(trigger=0, handler=self.pin_motion_test)
         interrupt_pin = machine.Pin(4, machine.Pin.OUT, machine.Pin.PULL_DOWN)
-        # time.sleep(0.2)
         LOG.info("Pin 4 has been pulled down")
         LOG.info("Entering Motor Demo State")
         LOG.info("To exit this state, reboot the device")
-        # state = machine.disable_irq()
-        # p.irq(trigger=0, handler=self.pin_motion_test)
-        # interrupt_pin = machine.Pin(4, machine.Pin.OUT, machine.Pin.PULL_DOWN)
         _thread.start_new_thread(self.move_thread, ())
-        # machine.enable_irq(state)
 
     def move_thread(self):
         import time
         LOG.info("Entering move thread, starting while loop")
         self.elevation.set_motor_position(45)
-        LOG.info("got past first elevation set")
         time.sleep(5)
         self.azimuth.set_motor_position(45)
-        LOG.info("got past second eleavtion set")
         time.sleep(10)
         while True:
             self.elevation.set_motor_position(20)
@@ -398,8 +388,9 @@ def esp32_antenna_api_factory():
         telemetry_sender,
         safe_mode,
     )
-    interrupt_pin = machine.Pin(4, machine.Pin.IN, machine.Pin.PULL_UP)
-    interrupt_pin.irq(trigger=machine.Pin.IRQ_FALLING, handler=api.antenna.pin_motion_test)
+    if config.get("enable_demo"):
+        interrupt_pin = machine.Pin(4, machine.Pin.IN, machine.Pin.PULL_UP)
+        interrupt_pin.irq(trigger=machine.Pin.IRQ_FALLING, handler=api.antenna.pin_motion_test)
 
     api.start()
     return api

--- a/nyansat/station/antenny.py
+++ b/nyansat/station/antenny.py
@@ -99,7 +99,7 @@ class AntennaController:
 
     def pin_motion_test(self, p):
         p.irq(trigger=0, handler=self.pin_motion_test)
-        interrupt_pin = machine.Pin(4, machine.Pin.OUT, machine.Pin.PULL_DOWN)
+        interrupt_pin = machine.Pin(15, machine.Pin.IN, machine.Pin.PULL_DOWN)
         LOG.info("Pin 4 has been pulled down")
         LOG.info("Entering Motor Demo State")
         LOG.info("To exit this state, reboot the device")
@@ -389,7 +389,7 @@ def esp32_antenna_api_factory():
         safe_mode,
     )
     if config.get("enable_demo"):
-        interrupt_pin = machine.Pin(4, machine.Pin.IN, machine.Pin.PULL_UP)
+        interrupt_pin = machine.Pin(15, machine.Pin.IN, machine.Pin.PULL_UP)
         interrupt_pin.irq(trigger=machine.Pin.IRQ_FALLING, handler=api.antenna.pin_motion_test)
 
     api.start()

--- a/nyansat/station/config/config.py
+++ b/nyansat/station/config/config.py
@@ -29,7 +29,7 @@ class ConfigRepository:
         "use_telemetry": False,
         "use_imu": False,
         "use_webrepl": False,
-        "enable_demo": False,
+        "enable_demo": True,
         # Elevation/azimuth servo defaults
         "elevation_servo_index": 0,
         "azimuth_servo_index": 1,

--- a/nyansat/station/config/config.py
+++ b/nyansat/station/config/config.py
@@ -29,6 +29,7 @@ class ConfigRepository:
         "use_telemetry": False,
         "use_imu": False,
         "use_webrepl": False,
+        "enable_demo": False,
         # Elevation/azimuth servo defaults
         "elevation_servo_index": 0,
         "azimuth_servo_index": 1,


### PR DESCRIPTION
May need to power-cycle the board before it works - sometimes shorting the pin causes the callback to trigger multiple times which hangs the system. 