### PR TITLE
Adds orientation warning before track, fixes TerminalPrinter

### DIFF
--- a/nyansat/host/shell/__main__.py
+++ b/nyansat/host/shell/__main__.py
@@ -29,13 +29,12 @@ class NyanShell(mpfshell.MpFileShell):
         super().__init__(color, caching, reset)
 
         self.client = AntennyClient(self.caching)
-        self.printer = TerminalPrinter()
         self._intro()
         self._set_prompt_path()
         self.emptyline = lambda: None
 
     def _intro(self):
-        self.intro = self.printer.intro()
+        self.intro = TerminalPrinter.intro()
 
     def _disconnect(self):
         return super()._MpFileShell__disconnect()
@@ -55,7 +54,7 @@ class NyanShell(mpfshell.MpFileShell):
             pwd = self.fe.pwd()
         else:
             pwd = "/"
-        self.prompt = self.printer.prompt(pwd)
+        self.prompt = TerminalPrinter.prompt(pwd)
 
     def do_open(self, args):
         """open <TARGET>
@@ -91,7 +90,7 @@ class NyanShell(mpfshell.MpFileShell):
         try:
             super().do_repl(args)
         except WebSocketConnectionClosedException as e:
-            self.printer.print_error("Connection lost to repl")
+            TerminalPrinter.print_error("Connection lost to repl")
             self._disconnect()
 
     @cli_handler

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -10,7 +10,7 @@ from time import sleep
 from dataclasses import dataclass
 from typing import List
 
-from nyansat.host.shell.terminal_printer import TerminalPrinter, print_warning
+from nyansat.host.shell.terminal_printer import TerminalPrinter
 from nyansat.host.shell.command_invoker import CommandInvoker
 from nyansat.host.shell.errors import *
 
@@ -127,7 +127,7 @@ class AntennyClient(object):
         self.guard_init()
         imu_enabled = self.invoker.config_get("use_imu")
         if imu_enabled == 'False':
-            TerminalPrinter().print_track_warning()
+            TerminalPrinter.print_track_warning()
         self.invoker.set_tracking(True)
         latitude = float(self.invoker.config_get("latitude"))
         longitude = float(self.invoker.config_get("longitude"))
@@ -171,7 +171,7 @@ class AntennyClient(object):
         data = (data['system'], data['gyroscope'], data['accelerometer'], data['magnetometer'])
         if not data:
             # TODO: should TerminalPrinter methods be static?
-            TerminalPrinter().print_error("Error connecting to BNO055.")
+            TerminalPrinter.print_error("Error connecting to BNO055.")
             return
 
         system_level, gyro_level, accel_level, magnet_level = data
@@ -180,7 +180,7 @@ class AntennyClient(object):
         accel_calibrated = accel_level > 0
         magnet_calibrated = magnet_level > 0
         components_calibrated = (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
-        TerminalPrinter()._display_initial_calibration_status(components_calibrated)
+        TerminalPrinter.display_initial_calibration_status(components_calibrated)
 
         waiting_dot_count = 4
         dot_counter = 0
@@ -188,7 +188,7 @@ class AntennyClient(object):
         while not (magnet_calibrated and accel_calibrated and gyro_calibrated):
             sleep(0.5)
             old_calibration_status = (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
-            system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = TerminalPrinter()._display_loop_calibration_status(
+            system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = TerminalPrinter.display_loop_calibration_status(
                 data,
                 old_calibration_status,
                 waiting_dot_count,
@@ -199,7 +199,7 @@ class AntennyClient(object):
             data = self.invoker.imu_calibration_status()
             data = (data['system'], data['gyroscope'], data['accelerometer'], data['magnetometer'])
             if not data:
-                TerminalPrinter().print_error("Error connecting to BNO055.")
+                TerminalPrinter.print_error("Error connecting to BNO055.")
                 return
 
             dot_counter = (dot_counter + 1) % waiting_dot_count
@@ -372,7 +372,7 @@ class AntennyClient(object):
             sda = int(input("SDA Pin#: "))
             scl = int(input("SCL Pin#: "))
         except ValueError:
-            TerminalPrinter().print_error("Invalid type for pin number. Try again using only decimal numbers")
+            TerminalPrinter.print_error("Invalid type for pin number. Try again using only decimal numbers")
             return
 
         bno_test_diagnostics = self.invoker.bno_diagnostics(sda, scl)
@@ -393,7 +393,7 @@ class AntennyClient(object):
             sda = int(input("SDA Pin#: "))
             scl = int(input("SCL Pin#: "))
         except ValueError:
-            TerminalPrinter().print_error("Invalid type for pin number. Try again using only decimal numbers")
+            TerminalPrinter.print_error("Invalid type for pin number. Try again using only decimal numbers")
             return
 
         pwm_test_diagnostics = self.invoker.pwm_diagnostics(sda, scl)
@@ -404,4 +404,3 @@ class AntennyClient(object):
         else:
             print("I2C address detected? True, addresses =", pwm_test_diagnostics.i2c_addresses)
         print("PWM connection established?", pwm_test_diagnostics.pca_object_created)
-

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -10,7 +10,7 @@ from time import sleep
 from dataclasses import dataclass
 from typing import List
 
-from nyansat.host.shell.terminal_printer import TerminalPrinter
+from nyansat.host.shell.terminal_printer import TerminalPrinter, print_warning
 from nyansat.host.shell.command_invoker import CommandInvoker
 from nyansat.host.shell.errors import *
 
@@ -125,6 +125,9 @@ class AntennyClient(object):
     def track(self, sat_name):
         self.guard_open()
         self.guard_init()
+        imu_enabled = self.invoker.config_get("use_imu")
+        if imu_enabled == 'False':
+            TerminalPrinter().print_track_warning()
         self.invoker.set_tracking(True)
         latitude = float(self.invoker.config_get("latitude"))
         longitude = float(self.invoker.config_get("longitude"))

--- a/nyansat/host/shell/antenny_client.py
+++ b/nyansat/host/shell/antenny_client.py
@@ -171,7 +171,6 @@ class AntennyClient(object):
         data = self.invoker.imu_calibration_status()
         data = (data['system'], data['gyroscope'], data['accelerometer'], data['magnetometer'])
         if not data:
-            # TODO: should TerminalPrinter methods be static?
             TerminalPrinter.print_error("Error connecting to BNO055.")
             return
 

--- a/nyansat/host/shell/errors.py
+++ b/nyansat/host/shell/errors.py
@@ -1,5 +1,8 @@
 import logging
-from nyansat.host.shell.terminal_printer import print_error
+
+from abc import ABC
+
+from nyansat.host.shell.terminal_printer import TerminalPrinter
 from mp.pyboard import PyboardError
 
 
@@ -11,7 +14,7 @@ def exception_handler(func):
         try:
             func(*args, **kwargs)
         except AntennyException as e:
-            print_error(e.msg + '\n')
+            TerminalPrinter.print_error(e.msg + '\n')
             print_board_error(e)
 
     return wrapper

--- a/nyansat/host/shell/errors.py
+++ b/nyansat/host/shell/errors.py
@@ -1,7 +1,5 @@
 import logging
 
-from abc import ABC
-
 from nyansat.host.shell.terminal_printer import TerminalPrinter
 from mp.pyboard import PyboardError
 

--- a/nyansat/host/shell/terminal_printer.py
+++ b/nyansat/host/shell/terminal_printer.py
@@ -5,18 +5,6 @@ import shutil
 import colorama
 
 
-def print_color(color, string):
-    print('\n' + color + string + colorama.Fore.RESET + '\n')
-
-
-def print_error(string):
-    print_color(colorama.Fore.RED, string)
-
-
-def print_warning(string):
-    print_color(colorama.Fore.YELLOW, string)
-
-
 class TerminalPrinter(object):
 
     YES_DISPLAY_STRING = colorama.Fore.GREEN + "YES" + colorama.Fore.RESET
@@ -27,7 +15,8 @@ class TerminalPrinter(object):
     MAGNET_CALIBRATION_MESSAGE = "To calibrate the magnetometer, move the sensor in figure-8 shapes through the air a " \
                                  "few times. "
 
-    def intro(self):
+    @staticmethod
+    def intro():
         """Text that appears when shell is first launched."""
         intro = (
             '\n' +
@@ -44,7 +33,8 @@ class TerminalPrinter(object):
         )
         return intro
 
-    def prompt(self, pwd):
+    @staticmethod
+    def prompt(pwd):
         """Terminal prompt text"""
         prompt = (
             colorama.Fore.BLUE +
@@ -57,10 +47,8 @@ class TerminalPrinter(object):
         )
         return prompt
 
-    def print_error(self, string):
-        print_color(colorama.Fore.RED, string)
-
-    def calibration_wait_message(self, gyro_calibrated, accel_calibrated, magnet_calibrated, use_ellipsis=True):
+    @staticmethod
+    def calibration_wait_message(gyro_calibrated, accel_calibrated, magnet_calibrated, use_ellipsis=True):
         """
         generate a human-readable message that indicates which components remain
         to be calibrated, e.g. if all the arguments are true, then it should
@@ -77,8 +65,8 @@ class TerminalPrinter(object):
         else:
             return "all components calibrated!"
 
-    def _display_initial_calibration_status(
-        self,
+    @staticmethod
+    def display_initial_calibration_status(
         calibration_status
     ):
         """
@@ -88,26 +76,27 @@ class TerminalPrinter(object):
                             status for the system, gyroscope, accelerometer, and magnetometer
         """
         system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = calibration_status
-        print("System calibrated?", f"{self.YES_DISPLAY_STRING}" if system_calibrated else self.NO_DISPLAY_STRING)
+        print("System calibrated?", f"{TerminalPrinter.YES_DISPLAY_STRING}"
+              if system_calibrated else TerminalPrinter.NO_DISPLAY_STRING)
         print("\n")
         if gyro_calibrated:
             print(" - Gyroscope is calibrated.")
         else:
-            print(f" - {self.GYRO_CALIBRATION_MESSAGE}")
+            print(f" - {TerminalPrinter.GYRO_CALIBRATION_MESSAGE}")
 
         if accel_calibrated:
             print(" - Accelerometer is calibrated.")
         else:
-            print(f" - {self.ACCEL_CALIBRATION_MESSAGE}")
+            print(f" - {TerminalPrinter.ACCEL_CALIBRATION_MESSAGE}")
 
         if magnet_calibrated:
             print(" - Magnetometer is calibrated.")
         else:
-            print(f" - {self.MAGNET_CALIBRATION_MESSAGE}")
+            print(f" - {TerminalPrinter.MAGNET_CALIBRATION_MESSAGE}")
         print("\n")
 
-    def _display_loop_calibration_status(
-        self,
+    @staticmethod
+    def display_loop_calibration_status(
         calibration_data,
         old_calibration_status,
         waiting_dot_count,
@@ -128,7 +117,7 @@ class TerminalPrinter(object):
         system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated = old_calibration_status
 
         print(" \n" * 8, end='')
-        self._display_initial_calibration_status(old_calibration_status)
+        TerminalPrinter.display_initial_calibration_status(old_calibration_status)
         print(" ")
 
         gyro_calibrated = gyro_calibrated or gyro_level > 0
@@ -140,14 +129,15 @@ class TerminalPrinter(object):
         waiting_dots = ('.' * dot_counter) + '/' + ('.' * (waiting_dot_count - dot_counter - 1))
         print("┌ CALIBRATION STATUS")
         print("│")
-        print("│ * Gyroscope calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {gyro_level}/3)" if gyro_calibrated else self.NO_DISPLAY_STRING)
-        print("│ * Accelerometer calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {accel_level}/3)" if accel_calibrated else self.NO_DISPLAY_STRING)
-        print("│ * Magnetometer calibrated?",
-                f"{self.YES_DISPLAY_STRING} (level {magnet_level}/3)" if magnet_calibrated else self.NO_DISPLAY_STRING)
+        print("│ * Gyroscope calibrated?", f"{TerminalPrinter.YES_DISPLAY_STRING} (level {gyro_level}/3)"
+              if gyro_calibrated else TerminalPrinter.NO_DISPLAY_STRING)
+        print("│ * Accelerometer calibrated?", f"{TerminalPrinter.YES_DISPLAY_STRING} (level {accel_level}/3)"
+              if accel_calibrated else TerminalPrinter.NO_DISPLAY_STRING)
+        print("│ * Magnetometer calibrated?", f"{TerminalPrinter.YES_DISPLAY_STRING} (level {magnet_level}/3)"
+              if magnet_calibrated else TerminalPrinter.NO_DISPLAY_STRING)
         print("│")
-        wait_message = self.calibration_wait_message(gyro_calibrated, accel_calibrated, magnet_calibrated, use_ellipsis=False)
+        wait_message = TerminalPrinter.calibration_wait_message(gyro_calibrated,
+                                                                accel_calibrated, magnet_calibrated, use_ellipsis=False)
         wait_message += (" " + waiting_dots if wait_message else "")
 
         # Write the wait message with an appropriate amount of trailing whitespace in order
@@ -158,9 +148,22 @@ class TerminalPrinter(object):
 
         return (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
 
-    def print_track_warning(self):
+    @staticmethod
+    def print_color(color, string):
+        print('\n' + color + string + colorama.Fore.RESET + '\n')
+
+    @staticmethod
+    def print_error(string):
+        TerminalPrinter.print_color(colorama.Fore.RED, string)
+
+    @staticmethod
+    def print_warning(string):
+        TerminalPrinter.print_color(colorama.Fore.YELLOW, string)
+
+    @staticmethod
+    def print_track_warning():
         msg = "WARNING: Your IMU is not enabled. For the tracking functionality to work, the station needs to \n"\
               "be oriented properly. Please run 'startmotion 0 90' and use your phone to orient the station to \n"\
               "point north. If you haven't already oriented it, use 'cancel' to exit tracking mode and properly \n"\
               "position your base station."
-        print_warning(msg)
+        TerminalPrinter.print_warning(msg)

--- a/nyansat/host/shell/terminal_printer.py
+++ b/nyansat/host/shell/terminal_printer.py
@@ -13,6 +13,10 @@ def print_error(string):
     print_color(colorama.Fore.RED, string)
 
 
+def print_warning(string):
+    print_color(colorama.Fore.YELLOW, string)
+
+
 class TerminalPrinter(object):
 
     YES_DISPLAY_STRING = colorama.Fore.GREEN + "YES" + colorama.Fore.RESET
@@ -154,5 +158,9 @@ class TerminalPrinter(object):
 
         return (system_calibrated, gyro_calibrated, accel_calibrated, magnet_calibrated)
 
-
-    pass
+    def print_track_warning(self):
+        msg = "WARNING: Your IMU is not enabled. For the tracking functionality to work, the station needs to \n"\
+              "be oriented properly. Please run 'startmotion 0 90' and use your phone to orient the station to \n"\
+              "point north. If you haven't already oriented it, use 'cancel' to exit tracking mode and properly \n"\
+              "position your base station."
+        print_warning(msg)


### PR DESCRIPTION
- If the IMU is not enabled, there is now a warning printed telling the user to orient the base station using their phone when they use the track command.
- The TerminalPrinter methods are now static since the only thing they do is print.